### PR TITLE
chore: remove devcontainers update configuration from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,3 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
This pull request updates the Dependabot configuration by removing support for automated updates of Dev Containers. This means Dependabot will no longer check for or create pull requests for updates to Dev Container definitions.

Configuration changes:

* Removed the `devcontainers` package-ecosystem from the `.github/dependabot.yml` file, disabling Dependabot updates for Dev Container configuration files.