### PR TITLE
chore: add cooldown configuration for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 1
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
This pull request makes a small configuration update to the Dependabot settings. The change introduces a cooldown period between updates.

- Dependabot configuration: Added a `cooldown` setting to enforce a 1-day delay between updates for dependencies in the root directory (`.github/dependabot.yml`).