### PR TITLE
chore: standardize quotes in static.yml for artifact path

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: '_site/'
+          path: "_site/"
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request makes a minor formatting change in the GitHub Actions workflow file by updating the artifact upload path to use double quotes for consistency.