### PR TITLE
chore: update copyright year in LICENSE to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2025 Takeshi Kishi
+Copyright (c) 2020-2026 Takeshi Kishi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This pull request makes a minor update to the `LICENSE` file, extending the copyright year to 2026.